### PR TITLE
Fix comment typo

### DIFF
--- a/base/session.go
+++ b/base/session.go
@@ -241,10 +241,14 @@ Add the middleware as follows
 
 The middleware does not create new sessions.  To create a session do the following.
 
-  session := c.Env["session"].(*Session)
-  if session == nil {
-	  sh := c.Env["sessionholder"].(SessionHolder)
-	  session = sh.Create()
+  var session *base.Session
+  s := c.Env["session"]
+
+  if s == nil {
+	sh := c.Env["sessionholder"].(base.SessionHolder)
+	session = sh.Create(c)
+  } else {
+	session = s.(*base.Session)
   }
 */
 func BuildSessionMiddleware(sh SessionHolder) func(c *web.C, h http.Handler) http.Handler {

--- a/base/session.go
+++ b/base/session.go
@@ -242,9 +242,9 @@ Add the middleware as follows
 The middleware does not create new sessions.  To create a session do the following.
 
   session := c.Env["session"].(*Session)
-  if session != nil {
+  if session == nil {
 	  sh := c.Env["sessionholder"].(SessionHolder)
-	  session := sh.Create()
+	  session = sh.Create()
   }
 */
 func BuildSessionMiddleware(sh SessionHolder) func(c *web.C, h http.Handler) http.Handler {


### PR DESCRIPTION
If I'm not mistaken, shouldn't it be like this

```
session := c.Env["session"].(*Session)
if session == nil {
    sh := c.Env["sessionholder"].(SessionHolder)
    session = sh.Create()
}
```

to create a session?
