### PR TITLE
Automatically add sessionid to cookie

### DIFF
--- a/base/session.go
+++ b/base/session.go
@@ -238,18 +238,6 @@ Add the middleware as follows
   sh := redis.NewSessionHolder()
   mux.Use(redis.BuildSessionMiddleware(sh))
   // Add handlers that use sessions
-
-The middleware does not create new sessions.  To create a session do the following.
-
-  var session *base.Session
-  s := c.Env["session"]
-
-  if s == nil {
-	sh := c.Env["sessionholder"].(base.SessionHolder)
-	session = sh.Create(c)
-  } else {
-	session = s.(*base.Session)
-  }
 */
 func BuildSessionMiddleware(sh SessionHolder) func(c *web.C, h http.Handler) http.Handler {
 	return func(c *web.C, h http.Handler) http.Handler {

--- a/base/session.go
+++ b/base/session.go
@@ -262,10 +262,15 @@ func BuildSessionMiddleware(sh SessionHolder) func(c *web.C, h http.Handler) htt
 				session.SetDirty(false)
 				c.Env["session"] = session
 			} else {
-				if err != ErrorSessionNotFound {
+				if err == ErrorSessionNotFound {
+					session = sh.Create(*c)
+					// add sessionid to cookie
+					sh.AddToResponse(*c, session, w)
+				} else {
 					log.Printf("error loading session %v", err)
 					http.Error(w, "Failed to load session data", http.StatusServiceUnavailable)
 				}
+
 			}
 			h.ServeHTTP(w, r)
 


### PR DESCRIPTION
I made a simple test app and realized that I need to do:

```
c.Env["sessionholder"].(base.SessionHolder).AddToResponse(*c, session, w)
```

to attach `sessionid` manually. So this pull request will automatically create session if it is not exist and attach the `sessionid` to cookie
