### PR TITLE
minor updates to session middleware

### DIFF
--- a/base/session.go
+++ b/base/session.go
@@ -186,10 +186,19 @@ func (sh *BaseSessionHolder) GenerateSessionId() string {
 	return strconv.FormatUint(a, 36) + strconv.FormatUint(b, 36) + strconv.FormatUint(c, 36) + strconv.FormatUint(d, 36)
 }
 
+/*
+GetTimeout retrieves the currently set TTL for session objects 
+*/
 func (sh *BaseSessionHolder) GetTimeout() int {
 	return sh.Timeout
 }
 
+/*
+SetTimeout updates the TTL for session objects
+
+Note that the TTL will only be updated for existing sessions when the session is requested again, it might timeout if
+this request takes too long to occur
+*/
 func (sh *BaseSessionHolder) SetTimeout(timeout int) {
 	sh.Timeout = timeout;
 }

--- a/base/session_test.go
+++ b/base/session_test.go
@@ -121,4 +121,31 @@ func TestSessionMiddleware(t *testing.T) {
 	if c.Env["session"].(*Session) != s {
 		t.Fatalf("session not added to c.Env")
 	}
+	
+	// store old sessionId
+	oldSessionId := s.Id();
+	// regenerate sessionId
+	sh.RegenerateId(c, s)
+	
+	// test if sessionId changed
+	if oldSessionId == s.Id() {
+		t.Fatalf("session ID did not change after regeneration request")
+	}
+
+	// Build a request referencing the session with its new id
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Header.Set("Cookie", fmt.Sprintf("sessionid=%s", s.Id()))
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	w := httptest.NewRecorder()
+	// Serve the request
+	m(&c, h).ServeHTTP(w, r)
+
+	if c.Env["session"].(*Session) != s {
+		t.Fatalf("session update not added to c.Env")
+	}
+	
 }

--- a/redis/session.go
+++ b/redis/session.go
@@ -120,6 +120,14 @@ func (sh *SessionHolder) RegenerateId(c web.C, session *base.Session) (string, e
 	return newSessionId, err
 }
 
+func (sh *SessionHolder) ResetTTL(c web.C, session *base.Session) error {
+	sessionId := session.Id()
+	conn := c.Env["redis"].(redigo.Conn)
+	_, err := conn.Do("EXPIRE", sessionKey(sessionId), sh.Timeout)
+	
+	return err
+}
+
 func sessionKey(sessionId string) string {
 	return fmt.Sprintf("sess:%s", sessionId)
 }


### PR DESCRIPTION
- RegenerateId allows you to regenerate the sessionId to fence off session fixation attacks
- SetTimeout allows to alter the session timeout in an easy way during runtime
- SetHttpOnly allows configuring http/server only session cookie
- SetSecure allows configuring secure https only session cookie
- BaseSessionHolder and session implementations (redis/memory) now implement ResetTTL  logic so session timeout counter resets to 0 on successful request, even if session data is unaltered in request handler
