### PR TITLE
minor updates to session middleware

### DIFF
--- a/base/session.go
+++ b/base/session.go
@@ -186,10 +186,19 @@ func (sh *BaseSessionHolder) GenerateSessionId() string {
 	return strconv.FormatUint(a, 36) + strconv.FormatUint(b, 36) + strconv.FormatUint(c, 36) + strconv.FormatUint(d, 36)
 }
 
+/*
+GetTimeout retrieves the currently set TTL for session objects 
+*/
 func (sh *BaseSessionHolder) GetTimeout() int {
 	return sh.Timeout
 }
 
+/*
+SetTimeout updates the TTL for session objects
+
+Note that the TTL will only be updated for existing sessions when the session is requested again, it might timeout if
+this request takes too long to occur
+*/
 func (sh *BaseSessionHolder) SetTimeout(timeout int) {
 	sh.Timeout = timeout;
 }

--- a/base/session.go
+++ b/base/session.go
@@ -228,9 +228,9 @@ func (sh *BaseSessionHolder) SetSecure(secure bool) {
 }
 
 /*
-SetPersistentCookie allows switching between persistent time out based cookies (MaxAge) and session lifetime cookies (no MaxAge)
+SetPersistentCookies allows switching between persistent time out based cookies (MaxAge) and session lifetime cookies (no MaxAge)
 */
-func (sh *BaseSessionHolder) SetPersistentCookie(persistent bool) {
+func (sh *BaseSessionHolder) SetPersistentCookies(persistent bool) {
 	sh.PersistentCookie = persistent
 }
 

--- a/base/session_test.go
+++ b/base/session_test.go
@@ -76,7 +76,7 @@ func TestBaseSessionHolderAddToResponse(t *testing.T) {
 	}
 	
 	w = httptest.NewRecorder()
-	sh.SetPersistentCookie(false)
+	sh.SetPersistentCookies(false)
 	sh.AddToResponse(c, s, w)
 	
 	cookie = w.HeaderMap.Get("Set-Cookie")

--- a/base/session_test.go
+++ b/base/session_test.go
@@ -71,7 +71,7 @@ func TestBaseSessionHolderAddToResponse(t *testing.T) {
 	sh.AddToResponse(c, s, w)
 
 	cookie := w.HeaderMap.Get("Set-Cookie")
-	if cookie != fmt.Sprintf("sessionid=%s; Path=/; Max-Age=30", s.Id()) {
+	if cookie != fmt.Sprintf("sessionid=%s; Path=/", s.Id()) {
 		t.Fatalf("Cookie not as expected - have %s", cookie)
 	}
 }
@@ -133,14 +133,14 @@ func TestSessionMiddleware(t *testing.T) {
 	}
 
 	// Build a request referencing the session with its new id
-	r, _ := http.NewRequest("GET", "/", nil)
+	r, _ = http.NewRequest("GET", "/", nil)
 	r.Header.Set("Cookie", fmt.Sprintf("sessionid=%s", s.Id()))
 
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})
 
-	w := httptest.NewRecorder()
+	w = httptest.NewRecorder()
 	// Serve the request
 	m(&c, h).ServeHTTP(w, r)
 

--- a/base/session_test.go
+++ b/base/session_test.go
@@ -121,4 +121,31 @@ func TestSessionMiddleware(t *testing.T) {
 	if c.Env["session"].(*Session) != s {
 		t.Fatalf("session not added to c.Env")
 	}
+	
+	// store old sessionId
+	oldSessionId := s.Id();
+	// regenerate sessionId
+	sh.RegenerateId(c, s)
+	
+	// test if sessionId changed
+	if oldSessionId == s.Id() {
+		t.Fatalf("session ID did not change after regeneration request")
+	}
+
+	// Build a request referencing the session with its new id
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Header.Set("Cookie", fmt.Sprintf("sessionid=%s", s.Id()))
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	w := httptest.NewRecorder()
+	// Serve the request
+	m(&c, h).ServeHTTP(w, r)
+
+	if c.Env["session"].(*Session) != s {
+		t.Fatalf("session update not added to c.Env")
+	}
+	
 }

--- a/base/session_test.go
+++ b/base/session_test.go
@@ -71,8 +71,17 @@ func TestBaseSessionHolderAddToResponse(t *testing.T) {
 	sh.AddToResponse(c, s, w)
 
 	cookie := w.HeaderMap.Get("Set-Cookie")
+	if cookie != fmt.Sprintf("sessionid=%s; Path=/; Max-Age=%d", s.Id(), sh.GetTimeout()) {
+		t.Fatalf("Persistent Cookie not as expected - have %s", cookie)
+	}
+	
+	w = httptest.NewRecorder()
+	sh.SetPersistentCookie(false)
+	sh.AddToResponse(c, s, w)
+	
+	cookie = w.HeaderMap.Get("Set-Cookie")
 	if cookie != fmt.Sprintf("sessionid=%s; Path=/", s.Id()) {
-		t.Fatalf("Cookie not as expected - have %s", cookie)
+		t.Fatalf("Session Cookie not as expected - have %s", cookie)
 	}
 }
 

--- a/redis/session.go
+++ b/redis/session.go
@@ -120,6 +120,14 @@ func (sh *SessionHolder) RegenerateId(c web.C, session *base.Session) (string, e
 	return newSessionId, err
 }
 
+func (sh *SessionHolder) ResetTTL(c web.C, session *base.Session) error {
+	sessionId := session.Id()
+	conn := c.Env["redis"].(redigo.Conn)
+	_, err := conn.Do("EXPIRE", sessionKey(sessionId), sh.Timeout)
+	
+	return err
+}
+
 func sessionKey(sessionId string) string {
 	return fmt.Sprintf("sess:%s", sessionId)
 }

--- a/redis/session_test.go
+++ b/redis/session_test.go
@@ -34,7 +34,7 @@ func TestSessionCreate(t *testing.T) {
 	sh.AddToResponse(c, s, w)
 
 	ch := w.HeaderMap.Get("Set-Cookie")
-	if ch != fmt.Sprintf("sessionid=%s; Path=/; Max-Age=2592000", s.Id()) {
+	if ch != fmt.Sprintf("sessionid=%s; Path=/", s.Id()) {
 		t.Fatalf("cookie header is %v", ch)
 	}
 

--- a/redis/session_test.go
+++ b/redis/session_test.go
@@ -34,7 +34,7 @@ func TestSessionCreate(t *testing.T) {
 	sh.AddToResponse(c, s, w)
 
 	ch := w.HeaderMap.Get("Set-Cookie")
-	if ch != fmt.Sprintf("sessionid=%s; Path=/", s.Id()) {
+	if ch != fmt.Sprintf("sessionid=%s; Path=/; Max-Age=%d", s.Id(), sh.GetTimeout()) {
 		t.Fatalf("cookie header is %v", ch)
 	}
 


### PR DESCRIPTION
RegenerateId allows you to regenerate the sessionId to fence off session fixation attacks
Cookie storing sessionid now has session scope (removed on browser close) and sessions time out server side
SetTimeout allows to alter the session timeout in an easy way during runtime
SetHttpOnly allows configuring http/server only session cookie
SetSecure allows configuring secure https only session cookie
BaseSessionHolder and session implementations (redis/memory) now implement ResetTTL logic so session timeout counter resets to 0 on successful request, even if session data is unaltered in request handler
